### PR TITLE
feat: improved search for artist

### DIFF
--- a/utils/apis/setlistFm.ts
+++ b/utils/apis/setlistFm.ts
@@ -1,7 +1,8 @@
 import axios from "axios";
 
 const DOMAIN = "https://api.setlist.fm";
-const PATH = "/rest/1.0/search/setlists?artistName=";
+const ARTIST_PATH = "/rest/1.0/search/artists?sort=relevance&artistName=";
+const SETLIST_PATH = "/rest/1.0/search/setlists?artistMbid=";
 
 const headers = {
   Accept: "application/json",
@@ -9,8 +10,14 @@ const headers = {
 };
 
 export const getArtistSetlist = async (artist: string) => {
-  const { data } = await axios(`${DOMAIN}${PATH}${artist}`, {
+  const { data: artistData } = await axios(`${DOMAIN}${ARTIST_PATH}${artist}`, {
     headers,
   });
+  const { data } = await axios(
+    `${DOMAIN}${SETLIST_PATH}${artistData?.artist?.[0].mbid}`,
+    {
+      headers,
+    }
+  );
   return data;
 };


### PR DESCRIPTION
`/search/setlist?artistName={artist}` in not returning the artist by relevance, a new call is needed to get the correct one.

in the detail:
```
/search/artists?artistName=beyonce&sort=relevance => correct
/search/setList?artistName=beyonce => returns ludmilla
```

how it has been solved:
- search the artist via `/search/arists` sorted by `relevance`
- get the `artistMbid`
- search the setlist using the `artistMbid`